### PR TITLE
chore: update registry for todo tools v1.1.0

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -23,9 +23,9 @@
       "id": "ziggle-dev/create-todo-list",
       "org": "ziggle-dev",
       "name": "create-todo-list",
-      "description": "Create and manage todo lists with priority levels and status tracking",
-      "latest": "1.0.0",
-      "version": "1.0.0",
+      "description": "Create a new todo list for planning and tracking tasks with shared state persistence",
+      "latest": "1.1.0",
+      "version": "1.1.0",
       "author": "ziggle-dev",
       "repository": "https://github.com/ziggle-dev/clanker-create-todo-list",
       "homepage": "https://github.com/ziggle-dev/clanker-create-todo-list",
@@ -33,7 +33,8 @@
       "created": "2025-07-27",
       "updated": "2025-07-27",
       "versions": [
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ],
       "publisher": "ziggle-dev"
     },
@@ -77,9 +78,9 @@
       "id": "ziggle-dev/update-todo-list",
       "org": "ziggle-dev",
       "name": "update-todo-list",
-      "description": "Update existing todo items with new status, priority, or content",
-      "latest": "1.0.0",
-      "version": "1.0.0",
+      "description": "Update existing todo items with new status, priority, or content using shared state persistence",
+      "latest": "1.1.0",
+      "version": "1.1.0",
       "author": "ziggle-dev",
       "repository": "https://github.com/ziggle-dev/clanker-update-todo-list",
       "homepage": "https://github.com/ziggle-dev/clanker-update-todo-list",
@@ -87,11 +88,12 @@
       "created": "2025-07-27",
       "updated": "2025-07-27",
       "versions": [
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
       ],
       "publisher": "ziggle-dev"
     }
   ],
-  "updated": "2025-07-27T01:02:11.927Z",
+  "updated": "2025-07-27T03:00:00.000Z",
   "totalTools": 5
 }


### PR DESCRIPTION
## Summary

This PR updates the registry.json file to reflect the new versions of the todo tools that now use the shared state API.

## Changes

- Updated create-todo-list from v1.0.0 to v1.1.0
- Updated update-todo-list from v1.0.0 to v1.1.0
- Updated descriptions to mention shared state persistence
- Updated registry timestamp

## Related Issues

- #46 - [Tool Submission] Create Todo List
- #47 - [Tool Submission] Update Todo List